### PR TITLE
Improve cumulative swipe momentum behavior

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -87,6 +87,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:decel", Hyprlang::FLOAT{0.92});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:min_velocity", Hyprlang::FLOAT{0.5});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:interval_ms", Hyprlang::INT{16});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:delta_multiplier", Hyprlang::FLOAT{1.25});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:debug", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_click", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_focus", Hyprlang::INT{0});


### PR DESCRIPTION
## Summary
- preserve residual momentum when a new swipe starts during decay instead of resetting velocity
- add `plugin:kinetic-scroll:delta_multiplier` config to scale gesture delta input (default `1.25`)
- apply scaled deltas consistently to smoothing, resume-additive, and initial seed paths for stronger acceleration buildup

## Why
Repeated touchpad swipes were feeling like each gesture restarted speed. This change makes momentum accumulation feel more natural and tunable.