### PR TITLE
Skip plugin inertia in browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ plugin:kinetic-scroll:decel = 0.99
 plugin:kinetic-scroll:min_velocity = 1.3
 plugin:kinetic-scroll:interval_ms = 8
 plugin:kinetic-scroll:delta_multiplier = 1.25
+plugin:kinetic-scroll:disable_in_browser = 1
 
 # Optional debug
 plugin:kinetic-scroll:debug = 0
@@ -77,6 +78,7 @@ Notes:
 - `min_velocity` is the cutoff threshold for stopping inertia.
 - `interval_ms` controls the decay frame rate (lower = smoother).
 - `delta_multiplier` scales swipe impulse (higher = faster acceleration buildup).
+- `disable_in_browser` keeps native browser kinetic scrolling when set to `1`.
 
 The plugin also respects Hyprland's `input:touchpad:scroll_factor` for
 synthetic events.

--- a/main.cpp
+++ b/main.cpp
@@ -88,6 +88,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:min_velocity", Hyprlang::FLOAT{0.5});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:interval_ms", Hyprlang::INT{16});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:delta_multiplier", Hyprlang::FLOAT{1.25});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:disable_in_browser", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:debug", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_click", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_focus", Hyprlang::INT{0});


### PR DESCRIPTION
## Summary
- add `plugin:kinetic-scroll:disable_in_browser` (default `1`)
- skip plugin momentum when focused app class looks like a browser (Firefox/Chromium/Brave/Vivaldi/Opera/LibreWolf/Zen)
- document the new option in README configuration notes

## Why
Most browsers already provide native kinetic scrolling. Disabling compositor-level inertia there avoids double behavior and keeps browser scrolling feel intact.