### PR TITLE
Stop inertia when scroll target changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ plugin:kinetic-scroll:min_velocity = 1.3
 plugin:kinetic-scroll:interval_ms = 8
 plugin:kinetic-scroll:delta_multiplier = 1.25
 plugin:kinetic-scroll:disable_in_browser = 1
+plugin:kinetic-scroll:stop_on_target_change = 1
 
 # Optional debug
 plugin:kinetic-scroll:debug = 0
@@ -79,6 +80,7 @@ Notes:
 - `interval_ms` controls the decay frame rate (lower = smoother).
 - `delta_multiplier` scales swipe impulse (higher = faster acceleration buildup).
 - `disable_in_browser` keeps native browser kinetic scrolling when set to `1`.
+- `stop_on_target_change` stops active inertia when scroll target window changes.
 
 The plugin also respects Hyprland's `input:touchpad:scroll_factor` for
 synthetic events.

--- a/kinetic.hpp
+++ b/kinetic.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <hyprland/src/devices/IPointer.hpp>
 #include <wayland-server-core.h>
+#include <cstdint>
 
 class KineticState {
   public:
@@ -15,11 +16,13 @@ class KineticState {
     static int onDecayTimer(void* data);
     void       emitSyntheticScroll();
 
-    double   m_velocityV    = 0.0;
-    double   m_velocityH    = 0.0;
-    uint32_t m_lastEventMs  = 0;
-    bool     m_tracking     = false;
-    bool     m_decaying     = false;
+    double    m_velocityV             = 0.0;
+    double    m_velocityH             = 0.0;
+    uint32_t  m_lastEventMs           = 0;
+    bool      m_tracking              = false;
+    bool      m_decaying              = false;
+    uintptr_t m_scrollTargetWindowKey = 0;
+    uintptr_t m_scrollTargetSurfaceKey = 0;
 
     wl_event_source* m_stopTimer  = nullptr;
     wl_event_source* m_decayTimer = nullptr;

--- a/main.cpp
+++ b/main.cpp
@@ -89,6 +89,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:interval_ms", Hyprlang::INT{16});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:delta_multiplier", Hyprlang::FLOAT{1.25});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:disable_in_browser", Hyprlang::INT{1});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_target_change", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:debug", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_click", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_focus", Hyprlang::INT{0});


### PR DESCRIPTION
## Summary
- add `plugin:kinetic-scroll:stop_on_target_change` (default `1`)
- track both focused window and pointer-focused surface and stop active inertia when target changes
- enforce browser exclusion during decay ticks as well, not only on incoming axis events
- document the new option in README

## Why
Inertia could continue after the scroll target changed (or when entering browser-native scroll contexts) because checks were only done on axis input. This stops momentum at the right moment during decay too.