### PR TITLE
feat: migrate to Hyprland 0.54.0 Event bus API

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,26 +2,34 @@
 #include "kinetic.hpp"
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <hyprland/src/devices/IPointer.hpp>
+#include <hyprland/src/event/EventBus.hpp>
+#include <hyprland/src/desktop/DesktopTypes.hpp>
 #include <unordered_map>
 #include <any>
 #include <fstream>
 
-static SP<HOOK_CALLBACK_FN> g_pAxisCallback;
-static SP<HOOK_CALLBACK_FN> g_pButtonCallback;
-static SP<HOOK_CALLBACK_FN> g_pWindowCallback;
+// Signal handlers - new Event bus API
+static CHyprSignalListener g_pAxisListener;
+static CHyprSignalListener g_pButtonListener;
+static CHyprSignalListener g_pWindowListener;
 
-static void onMouseAxis(void* /*self*/, SCallbackInfo& /*info*/, std::any data) {
+static void onMouseAxis(IPointer::SAxisEvent e, Event::SCallbackInfo& info) {
+    static auto const* PDEBUG =
+        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:debug")->getDataStaticPtr();
+    if (**PDEBUG) {
+        std::ofstream log("/tmp/hypr-kinetic-scroll.log", std::ios::app);
+        if (log.is_open())
+            log << "[hypr-kinetic-scroll] onMouseAxis called!\n";
+    }
+    
     if (!g_pKineticState)
         return;
-
-    auto eventData = std::any_cast<std::unordered_map<std::string, std::any>>(data);
-    auto e         = std::any_cast<IPointer::SAxisEvent>(eventData["event"]);
 
     g_pKineticState->onAxis(e);
     // Don't cancel - let the original scroll event pass through to the app
 }
 
-static void onMouseButton(void* /*self*/, SCallbackInfo& /*info*/, std::any data) {
+static void onMouseButton(IPointer::SButtonEvent e, Event::SCallbackInfo& info) {
     if (!g_pKineticState)
         return;
 
@@ -32,9 +40,6 @@ static void onMouseButton(void* /*self*/, SCallbackInfo& /*info*/, std::any data
 
     if (!**PSTOPCLICK)
         return;
-
-    auto eventData = std::any_cast<std::unordered_map<std::string, std::any>>(data);
-    auto e         = std::any_cast<IPointer::SButtonEvent>(eventData["event"]);
 
     if (e.state != WL_POINTER_BUTTON_STATE_PRESSED)
         return;
@@ -48,7 +53,10 @@ static void onMouseButton(void* /*self*/, SCallbackInfo& /*info*/, std::any data
     g_pKineticState->stopKinetic("mouseButton");
 }
 
-static void onActiveWindow(void* /*self*/, SCallbackInfo& /*info*/, std::any /*data*/) {
+static void onActiveWindow(PHLWINDOW window, Desktop::eFocusReason reason) {
+    (void)window;
+    (void)reason;
+    
     if (!g_pKineticState)
         return;
 
@@ -101,22 +109,21 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     // Create kinetic state (must be after compositor is ready, which it is during PLUGIN_INIT)
     g_pKineticState = new KineticState();
 
-    // Register event callbacks
-    g_pAxisCallback   = HyprlandAPI::registerCallbackDynamic(PHANDLE, "mouseAxis", onMouseAxis);
-    g_pButtonCallback = HyprlandAPI::registerCallbackDynamic(PHANDLE, "mouseButton", onMouseButton);
-    g_pWindowCallback = HyprlandAPI::registerCallbackDynamic(PHANDLE, "activeWindow", onActiveWindow);
+    // Register event callbacks using new Event bus API
+    g_pAxisListener = Event::bus()->m_events.input.mouse.axis.listen(onMouseAxis);
+    g_pButtonListener = Event::bus()->m_events.input.mouse.button.listen(onMouseButton);
+    g_pWindowListener = Event::bus()->m_events.window.active.listen(onActiveWindow);
 
     HyprlandAPI::addNotification(PHANDLE, "[hypr-kinetic-scroll] Loaded!", CHyprColor{0.2, 0.8, 0.2, 1.0}, 3000);
 
-    return {"hypr-kinetic-scroll", "Kinetic (inertial) scrolling for touchpads", "savonovv", "0.2.0"};
+    return {"hypr-kinetic-scroll", "Kinetic (inertial) scrolling for touchpads", "savonovv", "0.3.0"};
 }
 
 APICALL EXPORT void PLUGIN_EXIT() {
-    // Release callback refs (Hyprland auto-cleans registered callbacks on plugin unload,
-    // but resetting our SPs ensures deterministic ordering)
-    g_pAxisCallback.reset();
-    g_pButtonCallback.reset();
-    g_pWindowCallback.reset();
+    // Release signal listeners (when SP is reset, listener is unregistered)
+    g_pAxisListener.reset();
+    g_pButtonListener.reset();
+    g_pWindowListener.reset();
 
     // Clean up kinetic state (removes wl timers)
     delete g_pKineticState;


### PR DESCRIPTION
## Summary

This PR updates the plugin to be compatible with Hyprland 0.54.0 by migrating from the deprecated callback system to the new Event bus API.

## Changes

- **BREAKING**: Replace deprecated <code>registerCallbackDynamic()</code> with <code>Event::bus()->m_events.*.listen()</code>
- Update callback signatures from <code>(void*, SCallbackInfo&, std::any)</code> to typed handlers
- Migrate mouse axis/button events to <code>Event::bus()->m_events.input.mouse.*</code>
- Migrate window focus events to <code>Event::bus()->m_events.window.active</code>
- Bump version to 0.3.0

## Compatibility

- **Requires**: Hyprland 0.54.0 or later
- Previous versions will need to use v0.2.0

## Testing

- [x] Plugin loads successfully on Hyprland 0.54.0
- [x] Scroll inertia works correctly
- [x] Event handlers fire properly