### PR TITLE
feat: add per-app windowrules for kinetic scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ plugin:kinetic-scroll:stop_on_click = 0
 plugin:kinetic-scroll:stop_on_focus = 0
 ```
 
+### Per-App Window Rules
+
+You can enable or disable kinetic scrolling for specific apps using `kinetic-scroll-rule`:
+
+```ini
+kinetic-scroll-rule disable <class>   # disable kinetic scroll for app
+kinetic-scroll-rule enable <class>    # enable kinetic scroll for app
+```
+
+Find a window's class with `hyprctl clients` or `xprop`.
+
+Examples:
+```ini
+kinetic-scroll-rule disable firefox
+kinetic-scroll-rule disable chromium
+kinetic-scroll-rule enable steam
+```
+
 Notes:
 
 - `decel` is a multiplier applied each frame (lower = faster stop).

--- a/kinetic.cpp
+++ b/kinetic.cpp
@@ -25,6 +25,24 @@ struct SScrollTargetKeys {
     uintptr_t surfaceKey = 0;
 };
 
+bool KineticState::shouldProcessForWindow(const std::string& windowClass) {
+    auto it = m_perAppRules.find(windowClass);
+    if (it != m_perAppRules.end())
+        return it->second;
+    return true;
+}
+
+void KineticState::setAppRule(const std::string& appClass, bool enabled) {
+    m_perAppRules[appClass] = enabled;
+}
+
+bool KineticState::getAppRule(const std::string& appClass) const {
+    auto it = m_perAppRules.find(appClass);
+    if (it != m_perAppRules.end())
+        return it->second;
+    return true;
+}
+
 static SScrollTargetKeys currentScrollTargetKeys() {
     SScrollTargetKeys out;
 
@@ -84,6 +102,15 @@ void KineticState::onAxis(IPointer::SAxisEvent& e) {
         if (PWIN && classLooksLikeBrowser(PWIN->m_class)) {
             if (m_decaying)
                 stopKinetic("browserFocus");
+            return;
+        }
+    }
+
+    {
+        const auto PWIN = g_pInputManager ? g_pInputManager->m_lastMouseFocus.lock() : nullptr;
+        if (PWIN && !g_pKineticState->shouldProcessForWindow(PWIN->m_class)) {
+            if (m_decaying)
+                stopKinetic("appRule");
             return;
         }
     }
@@ -257,6 +284,14 @@ int KineticState::onDecayTimer(void* data) {
         const auto PWIN = g_pInputManager ? g_pInputManager->m_lastMouseFocus.lock() : nullptr;
         if (PWIN && classLooksLikeBrowser(PWIN->m_class)) {
             self->stopKinetic("browserDecay");
+            return 0;
+        }
+    }
+
+    {
+        const auto PWIN = g_pInputManager ? g_pInputManager->m_lastMouseFocus.lock() : nullptr;
+        if (PWIN && !self->shouldProcessForWindow(PWIN->m_class)) {
+            self->stopKinetic("appRuleDecay");
             return 0;
         }
     }

--- a/kinetic.hpp
+++ b/kinetic.hpp
@@ -2,6 +2,8 @@
 #include <hyprland/src/devices/IPointer.hpp>
 #include <wayland-server-core.h>
 #include <cstdint>
+#include <unordered_map>
+#include <string>
 
 class KineticState {
   public:
@@ -10,11 +12,14 @@ class KineticState {
 
     void onAxis(IPointer::SAxisEvent& e);
     void stopKinetic(const char* reason = nullptr);
+    void setAppRule(const std::string& appClass, bool enabled);
+    bool getAppRule(const std::string& appClass) const;
 
   private:
     static int onStopTimer(void* data);
     static int onDecayTimer(void* data);
     void       emitSyntheticScroll();
+    bool       shouldProcessForWindow(const std::string& windowClass);
 
     double    m_velocityV             = 0.0;
     double    m_velocityH             = 0.0;
@@ -26,4 +31,6 @@ class KineticState {
 
     wl_event_source* m_stopTimer  = nullptr;
     wl_event_source* m_decayTimer = nullptr;
+
+    std::unordered_map<std::string, bool> m_perAppRules;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -84,6 +84,39 @@ static void onConfigPreReload() {
         g_pKineticState->resetAppRules();
 }
 
+static Hyprlang::CParseResult parseKineticScrollRule(const char* /*command*/, const char* value) {
+    Hyprlang::CParseResult result;
+    std::istringstream     iss(value ? value : "");
+    std::string            mode, appClass;
+
+    if (!(iss >> mode)) {
+        result.setError("Invalid format: expected 'enable [class]' or 'disable [class]'");
+        return result;
+    }
+
+    bool enable = true;
+    if (mode == "disable")
+        enable = false;
+    else if (mode != "enable") {
+        result.setError("Invalid mode: expected 'enable' or 'disable'");
+        return result;
+    }
+
+    if (!(iss >> appClass)) {
+        g_pKineticState->setDefaultAppRule(enable);
+        return result;
+    }
+
+    std::string extra;
+    if (iss >> extra) {
+        result.setError("Invalid format: expected 'enable [class]' or 'disable [class]'");
+        return result;
+    }
+
+    g_pKineticState->setAppRule(appClass, enable);
+    return result;
+}
+
 APICALL EXPORT std::string PLUGIN_API_VERSION() {
     return HYPRLAND_API_VERSION;
 }
@@ -111,31 +144,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     // Create kinetic state (must be before registering keyword so it's available during config parse)
     g_pKineticState = new KineticState();
 
-    HyprlandAPI::addConfigKeyword(PHANDLE, "kinetic-scroll-rule",
-        [](const std::string& value) -> std::string {
-            std::istringstream iss(value);
-            std::string mode, appClass;
-            if (!(iss >> mode))
-                return "Invalid format: expected 'enable [class]' or 'disable [class]'";
-
-            bool enable = true;
-            if (mode == "disable")
-                enable = false;
-            else if (mode != "enable")
-                return "Invalid mode: expected 'enable' or 'disable'";
-
-            if (!(iss >> appClass)) {
-                g_pKineticState->setDefaultAppRule(enable);
-                return "";
-            }
-
-            std::string extra;
-            if (iss >> extra)
-                return "Invalid format: expected 'enable [class]' or 'disable [class]'";
-
-            g_pKineticState->setAppRule(appClass, enable);
-            return "";
-        }, {});
+    HyprlandAPI::addConfigKeyword(PHANDLE, "kinetic-scroll-rule", parseKineticScrollRule, {});
 
     // Register event callbacks
     g_pAxisCallback = listenRaw(Event::bus()->m_events.input.mouse.axis, [](void* data) {

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <any>
 #include <fstream>
+#include <sstream>
 
 static SP<HOOK_CALLBACK_FN> g_pAxisCallback;
 static SP<HOOK_CALLBACK_FN> g_pButtonCallback;
@@ -94,8 +95,28 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_click", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_focus", Hyprlang::INT{0});
 
-    // Create kinetic state (must be after compositor is ready, which it is during PLUGIN_INIT)
+    // Create kinetic state (must be before registering keyword so it's available during config parse)
     g_pKineticState = new KineticState();
+
+    HyprlandAPI::addConfigKeyword(PHANDLE, "kinetic-scroll-rule",
+        [](const std::string& value) -> std::string {
+            std::istringstream iss(value);
+            std::string mode, appClass;
+            if (!(iss >> mode >> appClass))
+                return "Invalid format: expected 'enable,class' or 'disable,class'";
+
+            bool enable = true;
+            if (mode == "disable")
+                enable = false;
+            else if (mode != "enable")
+                return "Invalid mode: expected 'enable' or 'disable'";
+
+            if (appClass.empty())
+                return "Missing app class";
+
+            g_pKineticState->setAppRule(appClass, enable);
+            return "";
+        }, {});
 
     // Register event callbacks
     g_pAxisCallback   = HyprlandAPI::registerCallbackDynamic(PHANDLE, "mouseAxis", onMouseAxis);


### PR DESCRIPTION
Adds `kinetic-scroll-rule` to enable or disable kinetic scrolling per application using exact window class matching.

Usage:

```ini
kinetic-scroll-rule disable <class>   # disable for one class
kinetic-scroll-rule enable <class>    # enable for one class
kinetic-scroll-rule disable           # disable by default
kinetic-scroll-rule enable            # enable by default
```

Examples:

```ini
kinetic-scroll-rule disable firefox
kinetic-scroll-rule disable chromium

# Enable only selected apps
kinetic-scroll-rule disable
kinetic-scroll-rule enable steam
```

Notes:
- Rules are reset and reparsed on Hyprland config reload.
- Explicit app rules override `plugin:kinetic-scroll:disable_in_browser`.
- Lua config support is intentionally left for a separate PR.

Verification:
- `git diff --check`
- `make -n`
- `make` attempted locally, but this environment lacks `pkg-config` and Hyprland headers.

Closes #8