### PR TITLE
Add Lua config functions for app rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ plugin:kinetic-scroll:interval_ms = 8
 plugin:kinetic-scroll:delta_multiplier = 1.25
 plugin:kinetic-scroll:disable_in_browser = 1
 plugin:kinetic-scroll:stop_on_target_change = 1
+plugin:kinetic-scroll:disabled_classes =
 
 # Optional debug
 plugin:kinetic-scroll:debug = 0
@@ -76,47 +77,21 @@ plugin:kinetic-scroll:stop_on_focus = 0
 
 ### Per-App Rules
 
-You can enable or disable kinetic scrolling per app using `kinetic-scroll-rule`.
-Rules use exact window class matching.
+For INI configs, disable kinetic scrolling per app with
+`plugin:kinetic-scroll:disabled_classes`. Classes are exact matches and can be
+separated by commas or spaces.
 
 ```ini
-kinetic-scroll-rule disable <class>   # disable kinetic scrolling for one class
-kinetic-scroll-rule enable <class>    # enable kinetic scrolling for one class
-
-kinetic-scroll-rule disable           # disable kinetic scrolling by default
-kinetic-scroll-rule enable            # enable kinetic scrolling by default
+plugin:kinetic-scroll:disabled_classes = org.telegram.desktop
+plugin:kinetic-scroll:disabled_classes = org.telegram.desktop, steam
 ```
 
 Find a window's class with `hyprctl clients` or `xprop`.
 
-Disable kinetic scrolling only in specific apps:
-
-```ini
-kinetic-scroll-rule disable firefox
-kinetic-scroll-rule disable chromium
-```
-
-Enable kinetic scrolling only in specific apps:
-
-```ini
-kinetic-scroll-rule disable
-kinetic-scroll-rule enable steam
-kinetic-scroll-rule enable org.gnome.Nautilus
-```
-
-Explicit app rules override `plugin:kinetic-scroll:disable_in_browser`. For
-example, this enables kinetic scrolling in Firefox while keeping the browser
-default for every other browser:
-
-```ini
-plugin:kinetic-scroll:disable_in_browser = 1
-kinetic-scroll-rule enable firefox
-```
-
 Lua configs can use the same exact class matching through plugin functions:
 
 ```lua
-hl.plugin.kinetic_scroll.disable("firefox")
+hl.plugin.kinetic_scroll.disable("org.telegram.desktop")
 hl.plugin.kinetic_scroll.disable("chromium")
 ```
 
@@ -138,6 +113,14 @@ hl.plugin.kinetic_scroll.disable_default()
 hl.plugin.kinetic_scroll.reset_rules()
 ```
 
+`kinetic-scroll-rule` is still available for older legacy INI configs that
+accept plugin keywords:
+
+```ini
+kinetic-scroll-rule disable firefox
+kinetic-scroll-rule enable firefox
+```
+
 Notes:
 
 - `decel` is a multiplier applied each frame (lower = faster stop).
@@ -145,7 +128,7 @@ Notes:
 - `interval_ms` controls the decay frame rate (lower = smoother).
 - `delta_multiplier` scales swipe impulse (higher = faster acceleration buildup).
 - `disable_in_browser` keeps native browser kinetic scrolling when set to `1`.
-- Per-app rules are reset and reparsed on Hyprland config reload.
+- `disabled_classes` disables kinetic scrolling for exact window classes.
 - `stop_on_target_change` stops active inertia when scroll target window changes.
 
 The plugin also respects Hyprland's `input:touchpad:scroll_factor` for

--- a/README.md
+++ b/README.md
@@ -113,6 +113,31 @@ plugin:kinetic-scroll:disable_in_browser = 1
 kinetic-scroll-rule enable firefox
 ```
 
+Lua configs can use the same exact class matching through plugin functions:
+
+```lua
+hl.plugin.kinetic_scroll.disable("firefox")
+hl.plugin.kinetic_scroll.disable("chromium")
+```
+
+To enable kinetic scrolling only in selected apps from Lua:
+
+```lua
+hl.plugin.kinetic_scroll.disable_default()
+hl.plugin.kinetic_scroll.enable("steam")
+hl.plugin.kinetic_scroll.enable("org.gnome.Nautilus")
+```
+
+Available Lua functions:
+
+```lua
+hl.plugin.kinetic_scroll.enable(class)
+hl.plugin.kinetic_scroll.disable(class)
+hl.plugin.kinetic_scroll.enable_default()
+hl.plugin.kinetic_scroll.disable_default()
+hl.plugin.kinetic_scroll.reset_rules()
+```
+
 Notes:
 
 - `decel` is a multiplier applied each frame (lower = faster stop).
@@ -120,7 +145,7 @@ Notes:
 - `interval_ms` controls the decay frame rate (lower = smoother).
 - `delta_multiplier` scales swipe impulse (higher = faster acceleration buildup).
 - `disable_in_browser` keeps native browser kinetic scrolling when set to `1`.
-- `kinetic-scroll-rule` entries are reset and reparsed on Hyprland config reload.
+- Per-app rules are reset and reparsed on Hyprland config reload.
 - `stop_on_target_change` stops active inertia when scroll target window changes.
 
 The plugin also respects Hyprland's `input:touchpad:scroll_factor` for

--- a/globals.hpp
+++ b/globals.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <hyprland/src/plugins/PluginAPI.hpp>
+#include <hyprland/src/config/ConfigValue.hpp>
 #include <string>
 
 inline HANDLE PHANDLE = nullptr;
@@ -8,19 +9,25 @@ class KineticState;
 inline KineticState* g_pKineticState = nullptr;
 
 inline int getKineticConfigInt(const std::string& name, int fallback) {
-    const auto VALUE = HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:" + name);
-    if (!VALUE)
+    const auto OPTION = CConfigValue<Config::INTEGER>("plugin:kinetic-scroll:" + name);
+    if (!OPTION.good())
         return fallback;
 
-    const auto DATA = (Hyprlang::INT* const*)VALUE->getDataStaticPtr();
-    return DATA && *DATA ? **DATA : fallback;
+    return *OPTION;
 }
 
 inline double getKineticConfigFloat(const std::string& name, double fallback) {
-    const auto VALUE = HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:" + name);
-    if (!VALUE)
+    const auto OPTION = CConfigValue<Config::FLOAT>("plugin:kinetic-scroll:" + name);
+    if (!OPTION.good())
         return fallback;
 
-    const auto DATA = (Hyprlang::FLOAT* const*)VALUE->getDataStaticPtr();
-    return DATA && *DATA ? **DATA : fallback;
+    return *OPTION;
+}
+
+inline std::string getKineticConfigString(const std::string& name, const std::string& fallback) {
+    const auto OPTION = CConfigValue<Config::STRING>("plugin:kinetic-scroll:" + name);
+    if (!OPTION.good())
+        return fallback;
+
+    return *OPTION;
 }

--- a/globals.hpp
+++ b/globals.hpp
@@ -1,7 +1,26 @@
 #pragma once
 #include <hyprland/src/plugins/PluginAPI.hpp>
+#include <string>
 
 inline HANDLE PHANDLE = nullptr;
 
 class KineticState;
 inline KineticState* g_pKineticState = nullptr;
+
+inline int getKineticConfigInt(const std::string& name, int fallback) {
+    const auto VALUE = HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:" + name);
+    if (!VALUE)
+        return fallback;
+
+    const auto DATA = (Hyprlang::INT* const*)VALUE->getDataStaticPtr();
+    return DATA && *DATA ? **DATA : fallback;
+}
+
+inline double getKineticConfigFloat(const std::string& name, double fallback) {
+    const auto VALUE = HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:" + name);
+    if (!VALUE)
+        return fallback;
+
+    const auto DATA = (Hyprlang::FLOAT* const*)VALUE->getDataStaticPtr();
+    return DATA && *DATA ? **DATA : fallback;
+}

--- a/kinetic.cpp
+++ b/kinetic.cpp
@@ -79,24 +79,14 @@ KineticState::~KineticState() {
 }
 
 void KineticState::onAxis(IPointer::SAxisEvent& e) {
-    static auto const* PENABLED =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:enabled")->getDataStaticPtr();
-    static auto const* PDISABLE_BROWSER =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:disable_in_browser")->getDataStaticPtr();
-    static auto const* PSTOPTARGET =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_target_change")->getDataStaticPtr();
-    static auto const* PDELTA_MUL =
-        (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:delta_multiplier")->getDataStaticPtr();
-    static auto const* PDEBUG =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:debug")->getDataStaticPtr();
     static uint64_t s_lastNotifyMs = 0;
 
-    if (!**PENABLED)
+    if (!getKineticConfigInt("enabled", 1))
         return;
 
     const auto targetKeys = currentScrollTargetKeys();
 
-    if (**PSTOPTARGET && m_scrollTargetWindowKey != 0) {
+    if (getKineticConfigInt("stop_on_target_change", 1) && m_scrollTargetWindowKey != 0) {
         const bool windowChanged = targetKeys.windowKey != 0 && targetKeys.windowKey != m_scrollTargetWindowKey;
         const bool surfaceChanged = targetKeys.surfaceKey != 0 && targetKeys.surfaceKey != m_scrollTargetSurfaceKey;
         if (windowChanged || surfaceChanged)
@@ -112,7 +102,7 @@ void KineticState::onAxis(IPointer::SAxisEvent& e) {
             return;
         }
 
-        if (**PDISABLE_BROWSER && !hasRule && classLooksLikeBrowser(PWIN->m_class)) {
+        if (getKineticConfigInt("disable_in_browser", 1) && !hasRule && classLooksLikeBrowser(PWIN->m_class)) {
             if (m_decaying)
                 stopKinetic("browserFocus");
             return;
@@ -128,12 +118,12 @@ void KineticState::onAxis(IPointer::SAxisEvent& e) {
     if (e.delta == 0.0 && e.deltaDiscrete == 0)
         return;
 
-    const double scaledDelta = e.delta * **PDELTA_MUL;
+    const double scaledDelta = e.delta * getKineticConfigFloat("delta_multiplier", 1.25);
 
     // New finger scroll while decaying => continue from current momentum
     const bool resumedFromDecay = m_decaying;
     if (resumedFromDecay) {
-        if (**PDEBUG) {
+        if (getKineticConfigInt("debug", 0)) {
             std::ofstream log("/tmp/hypr-kinetic-scroll.log", std::ios::app);
             if (log.is_open())
                 log << "[hypr-kinetic-scroll] onAxis: decaying -> resume self=" << this << "\n";
@@ -171,7 +161,7 @@ void KineticState::onAxis(IPointer::SAxisEvent& e) {
 
     m_lastEventMs = e.timeMs;
 
-    if (**PDEBUG) {
+    if (getKineticConfigInt("debug", 0)) {
         auto     now    = std::chrono::steady_clock::now();
         uint64_t nowMs  = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
         if (nowMs - s_lastNotifyMs > 200) {
@@ -200,9 +190,7 @@ void KineticState::onAxis(IPointer::SAxisEvent& e) {
 }
 
 void KineticState::stopKinetic(const char* reason) {
-    static auto const* PDEBUG =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:debug")->getDataStaticPtr();
-    if (**PDEBUG) {
+    if (getKineticConfigInt("debug", 0)) {
         std::ofstream log("/tmp/hypr-kinetic-scroll.log", std::ios::app);
         if (log.is_open())
             log << "[hypr-kinetic-scroll] stopKinetic reason=" << (reason ? reason : "(null)") << " self=" << this << "\n";
@@ -221,9 +209,7 @@ void KineticState::stopKinetic(const char* reason) {
 int KineticState::onStopTimer(void* data) {
     auto* self = static_cast<KineticState*>(data);
 
-    static auto const* PDEBUG =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:debug")->getDataStaticPtr();
-    if (**PDEBUG) {
+    if (getKineticConfigInt("debug", 0)) {
         std::ofstream log("/tmp/hypr-kinetic-scroll.log", std::ios::app);
         if (log.is_open()) {
             log << "[hypr-kinetic-scroll] stopTimer tracking=" << (self->m_tracking ? 1 : 0)
@@ -234,11 +220,9 @@ int KineticState::onStopTimer(void* data) {
     if (!self->m_tracking)
         return 0;
 
-    static auto const* PMINVEL =
-        (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:min_velocity")->getDataStaticPtr();
-
     // Only start kinetic if velocity is above threshold
-    if (std::abs(self->m_velocityV) < **PMINVEL && std::abs(self->m_velocityH) < **PMINVEL) {
+    const double minVelocity = getKineticConfigFloat("min_velocity", 0.5);
+    if (std::abs(self->m_velocityV) < minVelocity && std::abs(self->m_velocityH) < minVelocity) {
         self->m_tracking = false;
         return 0;
     }
@@ -247,25 +231,15 @@ int KineticState::onStopTimer(void* data) {
     self->m_tracking = false;
     self->m_decaying = true;
 
-    static auto const* PINTERVAL =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:interval_ms")->getDataStaticPtr();
-
-    wl_event_source_timer_update(self->m_decayTimer, **PINTERVAL);
+    wl_event_source_timer_update(self->m_decayTimer, getKineticConfigInt("interval_ms", 16));
     return 0;
 }
 
 int KineticState::onDecayTimer(void* data) {
     auto* self = static_cast<KineticState*>(data);
 
-    static auto const* PDEBUG =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:debug")->getDataStaticPtr();
-    static auto const* PDISABLE_BROWSER =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:disable_in_browser")->getDataStaticPtr();
-    static auto const* PSTOPTARGET =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_target_change")->getDataStaticPtr();
-
     if (!self->m_decaying) {
-        if (**PDEBUG) {
+        if (getKineticConfigInt("debug", 0)) {
             std::ofstream log("/tmp/hypr-kinetic-scroll.log", std::ios::app);
             if (log.is_open())
                 log << "[hypr-kinetic-scroll] decayTimer skipped (not decaying)\n";
@@ -275,7 +249,7 @@ int KineticState::onDecayTimer(void* data) {
 
     const auto targetKeys = currentScrollTargetKeys();
 
-    if (**PSTOPTARGET && self->m_scrollTargetWindowKey != 0) {
+    if (getKineticConfigInt("stop_on_target_change", 1) && self->m_scrollTargetWindowKey != 0) {
         const bool windowChanged  = targetKeys.windowKey != 0 && targetKeys.windowKey != self->m_scrollTargetWindowKey;
         const bool surfaceChanged = targetKeys.surfaceKey != 0 && targetKeys.surfaceKey != self->m_scrollTargetSurfaceKey;
         if (windowChanged || surfaceChanged) {
@@ -292,25 +266,20 @@ int KineticState::onDecayTimer(void* data) {
             return 0;
         }
 
-        if (**PDISABLE_BROWSER && !hasRule && classLooksLikeBrowser(PWIN->m_class)) {
+        if (getKineticConfigInt("disable_in_browser", 1) && !hasRule && classLooksLikeBrowser(PWIN->m_class)) {
             self->stopKinetic("browserDecay");
             return 0;
         }
     }
 
-    static auto const* PDECEL =
-        (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:decel")->getDataStaticPtr();
-    static auto const* PMINVEL =
-        (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:min_velocity")->getDataStaticPtr();
-    static auto const* PINTERVAL =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:interval_ms")->getDataStaticPtr();
-
     // Apply deceleration
-    self->m_velocityV *= **PDECEL;
-    self->m_velocityH *= **PDECEL;
+    const double decel = getKineticConfigFloat("decel", 0.92);
+    self->m_velocityV *= decel;
+    self->m_velocityH *= decel;
 
-    bool activeV = std::abs(self->m_velocityV) >= **PMINVEL;
-    bool activeH = std::abs(self->m_velocityH) >= **PMINVEL;
+    const double minVelocity = getKineticConfigFloat("min_velocity", 0.5);
+    bool activeV = std::abs(self->m_velocityV) >= minVelocity;
+    bool activeH = std::abs(self->m_velocityH) >= minVelocity;
 
     if (!activeV && !activeH) {
         self->stopKinetic("decayDone");
@@ -320,20 +289,19 @@ int KineticState::onDecayTimer(void* data) {
     self->emitSyntheticScroll();
 
     // Re-arm for next frame
-    wl_event_source_timer_update(self->m_decayTimer, **PINTERVAL);
+    wl_event_source_timer_update(self->m_decayTimer, getKineticConfigInt("interval_ms", 16));
     return 0;
 }
 
 void KineticState::emitSyntheticScroll() {
     static auto PSCROLLFACTOR = CConfigValue<Hyprlang::FLOAT>("input:touchpad:scroll_factor");
-    static auto const* PMINVEL =
-        (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:min_velocity")->getDataStaticPtr();
-
     auto     now         = std::chrono::steady_clock::now();
     uint32_t timeMs      = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
     double   scrollFactor = *PSCROLLFACTOR;
 
-    if (std::abs(m_velocityV) >= **PMINVEL) {
+    const double minVelocity = getKineticConfigFloat("min_velocity", 0.5);
+
+    if (std::abs(m_velocityV) >= minVelocity) {
         g_pSeatManager->sendPointerAxis(
             timeMs,
             WL_POINTER_AXIS_VERTICAL_SCROLL,
@@ -344,7 +312,7 @@ void KineticState::emitSyntheticScroll() {
             WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
     }
 
-    if (std::abs(m_velocityH) >= **PMINVEL) {
+    if (std::abs(m_velocityH) >= minVelocity) {
         g_pSeatManager->sendPointerAxis(
             timeMs,
             WL_POINTER_AXIS_HORIZONTAL_SCROLL,

--- a/kinetic.cpp
+++ b/kinetic.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <cstdint>
 #include <cctype>
+#include <sstream>
 
 static bool classLooksLikeBrowser(std::string cls) {
     for (auto& c : cls)
@@ -18,6 +19,26 @@ static bool classLooksLikeBrowser(std::string cls) {
     return cls.find("firefox") != std::string::npos || cls.find("chrom") != std::string::npos || cls.find("brave") != std::string::npos ||
            cls.find("vivaldi") != std::string::npos || cls.find("opera") != std::string::npos || cls.find("librewolf") != std::string::npos ||
            cls.find("zen") != std::string::npos;
+}
+
+static bool classInList(std::string cls, std::string list) {
+    for (auto& c : cls)
+        c = std::tolower(static_cast<unsigned char>(c));
+
+    for (auto& c : list) {
+        if (c == ',')
+            c = ' ';
+        else
+            c = std::tolower(static_cast<unsigned char>(c));
+    }
+
+    std::istringstream iss(list);
+    for (std::string item; iss >> item;) {
+        if (item == cls)
+            return true;
+    }
+
+    return false;
 }
 
 struct SScrollTargetKeys {
@@ -96,6 +117,12 @@ void KineticState::onAxis(IPointer::SAxisEvent& e) {
     const auto PWIN = g_pInputManager ? g_pInputManager->m_lastMouseFocus.lock() : nullptr;
     if (PWIN) {
         const bool hasRule = hasAppRule(PWIN->m_class);
+        if (classInList(PWIN->m_class, getKineticConfigString("disabled_classes", ""))) {
+            if (m_decaying)
+                stopKinetic("disabledClasses");
+            return;
+        }
+
         if (!shouldProcessForWindow(PWIN->m_class)) {
             if (m_decaying)
                 stopKinetic("appRule");
@@ -261,6 +288,11 @@ int KineticState::onDecayTimer(void* data) {
     const auto PWIN = g_pInputManager ? g_pInputManager->m_lastMouseFocus.lock() : nullptr;
     if (PWIN) {
         const bool hasRule = self->hasAppRule(PWIN->m_class);
+        if (classInList(PWIN->m_class, getKineticConfigString("disabled_classes", ""))) {
+            self->stopKinetic("disabledClassesDecay");
+            return 0;
+        }
+
         if (!self->shouldProcessForWindow(PWIN->m_class)) {
             self->stopKinetic("appRuleDecay");
             return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -3,25 +3,15 @@
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <hyprland/src/devices/IPointer.hpp>
 #include <hyprland/src/event/EventBus.hpp>
+#include <hyprland/src/config/values/types/FloatValue.hpp>
+#include <hyprland/src/config/values/types/IntValue.hpp>
+#include <hyprland/src/config/values/types/StringValue.hpp>
 #include <fstream>
 #include <sstream>
-#include <tuple>
-#include <utility>
 
 extern "C" {
 #include <lauxlib.h>
 #include <lua.h>
-}
-
-// Bypass header-side CSignalT::listen adapter so plugins keep working when the
-// running Hyprland was built against a different hyprutils minor version.
-struct SignalBaseAccessor : Hyprutils::Signal::CSignalBase {
-    using Hyprutils::Signal::CSignalBase::registerListenerInternal;
-};
-
-template <typename Signal, typename Handler>
-static Hyprutils::Signal::CHyprSignalListener listenRaw(Signal& signal, Handler handler) {
-    return reinterpret_cast<SignalBaseAccessor*>(&signal)->registerListenerInternal(std::move(handler));
 }
 
 static Hyprutils::Signal::CHyprSignalListener g_pAxisCallback;
@@ -153,6 +143,21 @@ static void registerLuaFunctions() {
     HyprlandAPI::addLuaFunction(PHANDLE, "kinetic_scroll", "reset_rules", luaResetRules);
 }
 
+static void registerConfigValues() {
+    using namespace Config::Values;
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:enabled", "Enable kinetic scrolling", 1));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CFloatValue>("plugin:kinetic-scroll:decel", "Kinetic deceleration multiplier", 0.92F));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CFloatValue>("plugin:kinetic-scroll:min_velocity", "Minimum velocity before stopping", 0.5F));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:interval_ms", "Kinetic timer interval", 16));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CFloatValue>("plugin:kinetic-scroll:delta_multiplier", "Scroll delta multiplier", 1.25F));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:disable_in_browser", "Disable kinetic scrolling in browsers", 1));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:stop_on_target_change", "Stop inertia when scroll target changes", 1));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:debug", "Enable kinetic scroll debug logging", 0));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:stop_on_click", "Stop inertia on mouse click", 0));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:stop_on_focus", "Stop inertia on focus change", 0));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CStringValue>("plugin:kinetic-scroll:disabled_classes", "Comma or space separated classes with kinetic scrolling disabled", ""));
+}
+
 APICALL EXPORT std::string PLUGIN_API_VERSION() {
     return HYPRLAND_API_VERSION;
 }
@@ -165,17 +170,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     // if (__hyprland_api_get_hash() != __hyprland_api_get_client_hash())
     //     throw std::runtime_error("Version mismatch");
 
-    // Register config values
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:enabled", Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:decel", Hyprlang::FLOAT{0.92});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:min_velocity", Hyprlang::FLOAT{0.5});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:interval_ms", Hyprlang::INT{16});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:delta_multiplier", Hyprlang::FLOAT{1.25});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:disable_in_browser", Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_target_change", Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:debug", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_click", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_focus", Hyprlang::INT{0});
+    registerConfigValues();
 
     // Create kinetic state (must be before registering keyword so it's available during config parse)
     g_pKineticState = new KineticState();
@@ -184,16 +179,10 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     registerLuaFunctions();
 
     // Register event callbacks
-    g_pAxisCallback = listenRaw(Event::bus()->m_events.input.mouse.axis, [](void* data) {
-        auto& args = *reinterpret_cast<std::tuple<const IPointer::SAxisEvent&, Event::SCallbackInfo&>*>(data);
-        onMouseAxis(std::get<0>(args), std::get<1>(args));
-    });
-    g_pButtonCallback = listenRaw(Event::bus()->m_events.input.mouse.button, [](void* data) {
-        auto& args = *reinterpret_cast<std::tuple<const IPointer::SButtonEvent&, Event::SCallbackInfo&>*>(data);
-        onMouseButton(std::get<0>(args), std::get<1>(args));
-    });
-    g_pWindowCallback = listenRaw(Event::bus()->m_events.window.active, [](void* /*data*/) { onActiveWindow(); });
-    g_pConfigReloadCallback = listenRaw(Event::bus()->m_events.config.preReload, [](void* /*data*/) { onConfigPreReload(); });
+    g_pAxisCallback = Event::bus()->m_events.input.mouse.axis.listen(onMouseAxis);
+    g_pButtonCallback = Event::bus()->m_events.input.mouse.button.listen(onMouseButton);
+    g_pWindowCallback = Event::bus()->m_events.window.active.listen(onActiveWindow);
+    g_pConfigReloadCallback = Event::bus()->m_events.config.preReload.listen(onConfigPreReload);
 
     HyprlandAPI::addNotification(PHANDLE, "[hypr-kinetic-scroll] Loaded!", CHyprColor{0.2, 0.8, 0.2, 1.0}, 3000);
 

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,11 @@
 #include <tuple>
 #include <utility>
 
+extern "C" {
+#include <lauxlib.h>
+#include <lua.h>
+}
+
 // Bypass header-side CSignalT::listen adapter so plugins keep working when the
 // running Hyprland was built against a different hyprutils minor version.
 struct SignalBaseAccessor : Hyprutils::Signal::CSignalBase {
@@ -117,6 +122,47 @@ static Hyprlang::CParseResult parseKineticScrollRule(const char* /*command*/, co
     return result;
 }
 
+static int luaSetAppRule(lua_State* L, bool enabled) {
+    const char* appClass = luaL_checkstring(L, 1);
+    if (g_pKineticState)
+        g_pKineticState->setAppRule(appClass, enabled);
+    return 0;
+}
+
+static int luaEnable(lua_State* L) {
+    return luaSetAppRule(L, true);
+}
+
+static int luaDisable(lua_State* L) {
+    return luaSetAppRule(L, false);
+}
+
+static int luaEnableDefault(lua_State* /*L*/) {
+    if (g_pKineticState)
+        g_pKineticState->setDefaultAppRule(true);
+    return 0;
+}
+
+static int luaDisableDefault(lua_State* /*L*/) {
+    if (g_pKineticState)
+        g_pKineticState->setDefaultAppRule(false);
+    return 0;
+}
+
+static int luaResetRules(lua_State* /*L*/) {
+    if (g_pKineticState)
+        g_pKineticState->resetAppRules();
+    return 0;
+}
+
+static void registerLuaFunctions() {
+    HyprlandAPI::addLuaFunction(PHANDLE, "kinetic_scroll", "enable", luaEnable);
+    HyprlandAPI::addLuaFunction(PHANDLE, "kinetic_scroll", "disable", luaDisable);
+    HyprlandAPI::addLuaFunction(PHANDLE, "kinetic_scroll", "enable_default", luaEnableDefault);
+    HyprlandAPI::addLuaFunction(PHANDLE, "kinetic_scroll", "disable_default", luaDisableDefault);
+    HyprlandAPI::addLuaFunction(PHANDLE, "kinetic_scroll", "reset_rules", luaResetRules);
+}
+
 APICALL EXPORT std::string PLUGIN_API_VERSION() {
     return HYPRLAND_API_VERSION;
 }
@@ -145,6 +191,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     g_pKineticState = new KineticState();
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "kinetic-scroll-rule", parseKineticScrollRule, {});
+    registerLuaFunctions();
 
     // Register event callbacks
     g_pAxisCallback = listenRaw(Event::bus()->m_events.input.mouse.axis, [](void* data) {

--- a/main.cpp
+++ b/main.cpp
@@ -42,17 +42,12 @@ static void onMouseButton(const IPointer::SButtonEvent& e, Event::SCallbackInfo&
     if (!g_pKineticState)
         return;
 
-    static auto const* PSTOPCLICK =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_click")->getDataStaticPtr();
-    static auto const* PDEBUG =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:debug")->getDataStaticPtr();
-
-    if (!**PSTOPCLICK)
+    if (!getKineticConfigInt("stop_on_click", 0))
         return;
 
     if (e.state != WL_POINTER_BUTTON_STATE_PRESSED)
         return;
-    if (**PDEBUG) {
+    if (getKineticConfigInt("debug", 0)) {
         std::ofstream log("/tmp/hypr-kinetic-scroll.log", std::ios::app);
         if (log.is_open())
             log << "[hypr-kinetic-scroll] mouseButton -> stopKinetic\n";
@@ -66,15 +61,10 @@ static void onActiveWindow() {
     if (!g_pKineticState)
         return;
 
-    static auto const* PSTOPFOCUS =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:stop_on_focus")->getDataStaticPtr();
-
-    if (!**PSTOPFOCUS)
+    if (!getKineticConfigInt("stop_on_focus", 0))
         return;
 
-    static auto const* PDEBUG =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:kinetic-scroll:debug")->getDataStaticPtr();
-    if (**PDEBUG) {
+    if (getKineticConfigInt("debug", 0)) {
         std::ofstream log("/tmp/hypr-kinetic-scroll.log", std::ios::app);
         if (log.is_open())
             log << "[hypr-kinetic-scroll] activeWindow -> stopKinetic\n";


### PR DESCRIPTION
## Summary
- add `hl.plugin.kinetic_scroll` Lua functions for per-app kinetic scroll rules
- support exact class matching from Lua with `enable(class)` and `disable(class)`
- support default rule control with `enable_default()`, `disable_default()`, and `reset_rules()`
- document the Lua config workflow in README
- avoid cached plugin config pointers after a tester crash report on this branch

## Lua API
```lua
hl.plugin.kinetic_scroll.enable("firefox")
hl.plugin.kinetic_scroll.disable("chromium")
hl.plugin.kinetic_scroll.enable_default()
hl.plugin.kinetic_scroll.disable_default()
hl.plugin.kinetic_scroll.reset_rules()
```

## Crash report note
The report from testing this PR showed a SIGSEGV inside `hypr-kinetic-scroll.so` while Hyprland emitted `window.active`. This branch now avoids caching pointers returned by deprecated `getConfigValue(...)->getDataStaticPtr()` and reads plugin config values immediately with fallbacks instead.

## Verification
- `git diff --check`
- `make -n`
- `make` attempted locally, but this environment lacks `pkg-config` and Hyprland headers.