### PR TITLE
Removed load notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Add these to your Hyprland config (e.g. `~/.config/hypr/input.conf`):
 
 ```ini
 plugin:kinetic-scroll:enabled = 1
-plugin:kinetic-scroll:decel = 0.99
-plugin:kinetic-scroll:min_velocity = 1.3
-plugin:kinetic-scroll:interval_ms = 8
+plugin:kinetic-scroll:decel = 0.92
+plugin:kinetic-scroll:min_velocity = 0.5
+plugin:kinetic-scroll:interval_ms = 16
 plugin:kinetic-scroll:delta_multiplier = 1.25
 plugin:kinetic-scroll:disable_in_browser = 1
 plugin:kinetic-scroll:stop_on_target_change = 1

--- a/main.cpp
+++ b/main.cpp
@@ -152,10 +152,10 @@ static void registerConfigValues() {
     HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CFloatValue>("plugin:kinetic-scroll:delta_multiplier", "Scroll delta multiplier", 1.25F));
     HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:disable_in_browser", "Disable kinetic scrolling in browsers", 1));
     HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:stop_on_target_change", "Stop inertia when scroll target changes", 1));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CStringValue>("plugin:kinetic-scroll:disabled_classes", "Comma or space separated classes with kinetic scrolling disabled", ""));
     HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:debug", "Enable kinetic scroll debug logging", 0));
     HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:stop_on_click", "Stop inertia on mouse click", 0));
     HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:stop_on_focus", "Stop inertia on focus change", 0));
-    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CStringValue>("plugin:kinetic-scroll:disabled_classes", "Comma or space separated classes with kinetic scrolling disabled", ""));
 }
 
 APICALL EXPORT std::string PLUGIN_API_VERSION() {
@@ -183,8 +183,6 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     g_pButtonCallback = Event::bus()->m_events.input.mouse.button.listen(onMouseButton);
     g_pWindowCallback = Event::bus()->m_events.window.active.listen(onActiveWindow);
     g_pConfigReloadCallback = Event::bus()->m_events.config.preReload.listen(onConfigPreReload);
-
-    HyprlandAPI::addNotification(PHANDLE, "[hypr-kinetic-scroll] Loaded!", CHyprColor{0.2, 0.8, 0.2, 1.0}, 3000);
 
     return {"hypr-kinetic-scroll", "Kinetic (inertial) scrolling for touchpads", "savonovv", "0.1"};
 }


### PR DESCRIPTION
I also changed the options displayed in the README to show the actual defaults instead of random values.

I tried adding `plugin:kinetic_scroll:load_notification` and make it 0 by default but it looks like that won't actually gets parsed until after initialization, meaning that `getKineticConfigInt("load_notification", 123)` would always return 0 (if declared as `HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<CIntValue>("plugin:kinetic-scroll:load_notification", "Display a notification upon plugin load", 0));`) instead of the value actually specified in the config, at least when called from `PLUGIN_INIT`.

I'm open to adding it back as an option if you know how that could be fixed.

Closes https://github.com/savonovv/hypr-kinetic-scroll/issues/17